### PR TITLE
Compose network_mode host for windows and SetRate for ardupilot local_position messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ This folder contains a number of simple example general controllers for general 
 
 #### Building
 
-The examples can be built and run via `docker-compose`. 
+The examples can be built and run via `docker-compose`.
 
-First, start up one of the docker-compose simulator stacks in ProjectStarling (i.e. [docker-compose.yml](https://github.com/StarlingUAS/ProjectStarling/blob/master/docker-compose.yml)), [Murmuration](https://github.com/StarlingUAS/Murmuration) or [FenswoodScenario](https://github.com/StarlingUAS/FenswoodScenario). 
+First, start up one of the docker-compose simulator stacks in ProjectStarling (i.e. [docker-compose.yml](https://github.com/StarlingUAS/ProjectStarling/blob/master/docker-compose.yml)), [Murmuration](https://github.com/StarlingUAS/Murmuration) or [FenswoodScenario](https://github.com/StarlingUAS/FenswoodScenario).
 ```bash
 docker-compose -f <simulator/sitl/mavros compose file> up
 ```
@@ -23,7 +23,7 @@ docker-compose -f docker-compose.px4.yaml up
 docker-compose -f docker-compose.ap.yaml up
 ```
 
-This command will both build and run the local files (the compose file uses the 'build' entry to specify the location of building). If you make any local changes to the controller, the controller can be rebuilt by using the `--build` flag, e.g. 
+This command will both build and run the local files (the compose file uses the 'build' entry to specify the location of building). If you make any local changes to the controller, the controller can be rebuilt by using the `--build` flag, e.g.
 
 ```bash
 docker-compose -f docker-compose.px4.yaml up --build
@@ -47,17 +47,17 @@ STARLING_NETWORK='<Name of compose network>'; docker-compose -f docker-compose.a
 
 **Using Powershell**:
 ```ps1
-$env:STARLING_NETWORK = '<Name of compose network>'; 
+$env:STARLING_NETWORK = '<Name of compose network>';
 docker-compose -f docker-compose.ap.yaml up
 
 # Then when you are finished using these environment variables
 Remove-Item Env:\STARLING_NETWORK
 ```
 
-2. **Linux** - If running with the `linux` variant of the simulator compose files, you will need to specify that the environment variable `STARLING_NETWORK_MODE='host'`:
+2. **Linux** - If running with the `linux` variant of the simulator compose files, you will not need to make any changes. By default the file already uses `host` networking. Whilst this fails on windows, therefore dropping to use the default network, on linux this succeeds.
 
 ```bash
-STARLING_NETWORK_MODE='host'; docker-compose -f docker-compose.ap.yaml up
+docker-compose -f docker-compose.ap.yaml up
 ```
 
 ### Through Makefile
@@ -77,18 +77,16 @@ This will run the local uobflightlabstarling/example_controller_python_ap/_px4 i
 
 ## Fenswood Scenario Example Controller
 
-An example controller is provided which attempts to solve the Fenswood Scenario target landing problem in [FenswoodScenario](https://github.com/StarlingUAS/FenswoodScenario). 
+An example controller is provided which attempts to solve the Fenswood Scenario target landing problem in [FenswoodScenario](https://github.com/StarlingUAS/FenswoodScenario).
 
-To run the fenswood ardupilot example controller, first start up the fenswood scenario simulation compose file for your particular operating system. 
+To run the fenswood ardupilot example controller, first start up the fenswood scenario simulation compose file for your particular operating system.
 
-Then, the fenswood compose file will start the example fenswood controller. 
+Then, the fenswood compose file will start the example fenswood controller.
 ```bash
 docker-compose -f docker-compose.fenswood.ap.yaml up
 ```
 
-As described above, if you are running on linux you may need to specify `STARLING_NETWORK_MODE='host'` before running `up`. 
-
-The controller simply follows a trajectory, specified by a set of hardcoded points within the controller. 
+The controller simply follows a trajectory, specified by a set of hardcoded points within the controller.
 
 ## Example Python Controller
 

--- a/docker-compose.ap.yaml
+++ b/docker-compose.ap.yaml
@@ -3,8 +3,8 @@ version: '3'
 services:
 
   controller:
-    build: example_controller_python_ap/
-    network_mode: ${STARLING_NETWORK_MODE:-bridge}
+    build: ./example_controller_python_ap/
+    network_mode: host
 
 networks:
   default:

--- a/docker-compose.fenswood.ap.yaml
+++ b/docker-compose.fenswood.ap.yaml
@@ -2,8 +2,8 @@ version: '3'
 
 services:
   controller:
-    build: example_controller_python_ap/
-    network_mode: ${STARLING_NETWORK_MODE:-bridge}
+    build: ./example_controller_python_ap/
+    network_mode: host
     command: ["ros2", "launch", "example_controller_python", "fenswood_example.launch.py"]
 
 

--- a/docker-compose.px4.yaml
+++ b/docker-compose.px4.yaml
@@ -3,8 +3,8 @@ version: '3'
 services:
 
   controller:
-    build: example_controller_python_px4/
-    network_mode: ${STARLING_NETWORK_MODE:-bridge}
+    build: ./example_controller_python_px4/
+    network_mode: host
 
 networks:
   default:

--- a/example_controller_python_ap/example_controller_python/fenswood_controller.py
+++ b/example_controller_python_ap/example_controller_python/fenswood_controller.py
@@ -68,7 +68,12 @@ class DemoController(Node):
         self.offboard_client = self.create_client(
             mavros_msgs.srv.SetMode,
             f'mavros/set_mode')
-        
+
+        self.stream_rate_limiter = RateLimiter(1,self.get_clock())
+        self.stream_rate_client = self.create_client(
+            mavros_msgs.srv.StreamRate,
+            f'mavros/set_stream_rate')   
+
         self.arm_rate_limiter = RateLimiter(1,self.get_clock())
         self.arming_client = self.create_client(
             mavros_msgs.srv.CommandBool,
@@ -98,7 +103,7 @@ class DemoController(Node):
         timer_period = 0.02
         self.timer = self.create_timer(timer_period, self.timer_callback)
 
-        self.vehicle_position = PoseStamped()
+        self.vehicle_position = None
         self.vehicle_state = mavros_msgs.msg.State()
 
 
@@ -151,6 +156,14 @@ class DemoController(Node):
             self.state = 'DEAD'
 
         if self.state == 'Init':
+            if self.initial_position==None and self.vehicle_position == None: # Request vehicle position from GCS
+                commandCall = mavros_msgs.srv.StreamRate.Request()
+                commandCall.stream_id = 6 # Request position streaming
+                commandCall.message_rate = 20 # Request at 20hz
+                commandCall.on_off = True
+                self.stream_rate_limiter.call(lambda: self.stream_rate_client.call_async(commandCall))
+                self.logger.info("Sent Set Message Interval Request (Ardupilot)")
+
             if self.initial_position == None and self.vehicle_position != None:
                 self.initial_position = copy.deepcopy(self.vehicle_position)
                 self.logger.info("Got initial position: ({},{},{})".format(


### PR DESCRIPTION
This PR closes #3 as `network_mode: bridge` appears to not use `default` network. Changing `network_mode: host` oddly appears to provide the correct behaviour. I suspect that `host` on windows might just be ignored and the default network used instead. 

This actually simplifies deployment on windows/linux as now there is no change between the two compose files. 

Also changed the build target to start with `./` so that powershell understands where the folder to be build is. 

Verified this works on windows (wsl2 and powershell), need to verify it still works on linux. 